### PR TITLE
feat(channel-web): allow usage of contentElement for fileUpload message

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -275,7 +275,7 @@ export default async (bp: typeof sdk, db: Database) => {
         size: req.file.size
       }
 
-      if (config.uploadsFileUploadedTextContentElement) {
+      if (config.uploadsFileUploadedTextContentElement?.length) {
         try {
           if (!config.uploadsFileUploadedTextContentElement.startsWith('#!builtin_text')) {
             throw new Error('Only builtin_text elements are supported, use #!builtin_text-<elementId>')

--- a/modules/channel-web/src/config.ts
+++ b/modules/channel-web/src/config.ts
@@ -3,7 +3,7 @@ export interface Config {
    * Specify a builtin_text contentElement to be sent to the user after a file upload
    * example: #!builtin_text-OzpN5X (only builtin_text contentElements are supported)
    *
-   * Varibles available:
+   * Variables available:
    *  storage: 'local' or 's3'
    *  url: URL where the file has been uploaded
    *  originalName: Name that the file had on the user's computer

--- a/modules/channel-web/src/config.ts
+++ b/modules/channel-web/src/config.ts
@@ -1,5 +1,19 @@
 export interface Config {
   /**
+   * Specify a builtin_text contentElement to be sent to the user after a file upload
+   * example: #!builtin_text-OzpN5X (only builtin_text contentElements are supported)
+   *
+   * Varibles available:
+   *  storage: 'local' or 's3'
+   *  url: URL where the file has been uploaded
+   *  originalName: Name that the file had on the user's computer
+   *  mime: mime type of the file, example: 'image/gif'
+   *  size: size from the file in bytes
+   *
+   * User variables are also available at 'event.state.user' (only user variables are supported)
+   */
+  uploadsFileUploadedTextContentElement?: string
+  /**
    * @default false
    */
   uploadsUseS3?: boolean


### PR DESCRIPTION
Adds a channel-web module configuration variable "uploadsFileUploadedTextContentElement" that allows specifying a text content element to be rendered and sent to the user after a file upload (by default, it sends "Uploaded a file **originalName**")

OBS: Only set it on the bot-scoped channel-web configuration since content element IDs are specific for each bot (right-click on the global config file and 'Duplicate to current bot').

![image](https://github.com/botpress/v12/assets/13484138/f3cc6a55-1ded-42bb-af13-ac7595caa789)

To use, create a builtin_text content element:

![image](https://github.com/botpress/v12/assets/13484138/a77908a3-261b-46cc-80a1-c40984a6f04b)

After, get the content element id, for example: "#!builtin_text-OzpN5X" (only builtin_text contentElements are supported)

Variables available:

storage: 'local' or 's3'
url: URL where the file has been uploaded
originalName: Name that the file had on the user's computer
mime: mime type of the file, example: 'image/gif'
size: size from the file in bytes

User variables are also available at 'event.state.user' (only user variables are supported)

![image](https://github.com/botpress/v12/assets/13484138/40e665e6-c578-477d-9321-13e1e5f47c46)

Content Element Multilanguage is also supported:

![image](https://github.com/botpress/v12/assets/13484138/da4f530e-c51c-4f72-b545-0c16c5b83466)
